### PR TITLE
feat(data_submission): initialize OTLP meter provider at startup

### DIFF
--- a/data_submission/src/main.rs
+++ b/data_submission/src/main.rs
@@ -25,7 +25,7 @@ use diesel_async::{
     AsyncPgConnection,
 };
 use enigma::EnigmaEncryptionService;
-use observability::init_tracer;
+use observability::{init_meter, init_tracer};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 use turbo_da_core::utils::generate_keygen_list;
@@ -35,6 +35,7 @@ use workload_scheduler::consumer::Consumer;
 #[tracing::instrument(name = "data_submission_service")]
 async fn main() -> Result<(), std::io::Error> {
     let _guard = init_tracer("data_submission");
+    init_meter("data_submission");
 
     let app_config = AppConfig::default().load_config()?;
 


### PR DESCRIPTION
## Summary

`observability::init_meter()` is defined in `observability/src/oltp.rs` but never called from `data_submission/src/main.rs`. Without a global `MeterProvider`, every custom counter emitted via `log_txn` / `log_retry_count` / `log_fallback_txn_error` (e.g. `turboDA.success_txn`, `turboDA.failed_txn`, `turboDA.fallback_retry_count`) is silently dropped. `ENABLE_OTEL_METRICS=true` has no effect on the app-level pipeline today.

This one-liner invokes `init_meter("data_submission")` alongside `init_tracer` so those counters actually reach the OTLP collector.

## Context

Surfaced during an observability audit — the `data_submission` service did not appear in SigNoz's service list despite `ENABLE_OTEL_METRICS=true` and `OTLP_RECEIVER_URL` being set. Two root causes:

1. **Network path**: `OTLP_RECEIVER_URL=http://otel2.avail.so` resolves IPv6-only from inside the pod and lacks an explicit port (tonic defaults to :80). Already fixed on the helm-values side by redirecting to `otel-collector-opentelemetry-collector.infrastructure.svc.cluster.local:4317`.
2. **Missing init** (this PR): meter provider never initialized.

## Test plan

- [x] `cargo check -p data_submission` passes clean
- [ ] Post-deploy verification: `turboDA.success_txn` counter appears in SigNoz after a submission completes on the new image

## Follow-up (separate step, not in this PR)

After this merges and a new image is published, bump `image.tag` in:
- `environment/fra1-production/networks/mainnet/mainnet-turboda-data-submission-api/values.yaml`
- `environment/fra1-production/networks/turing/turing-turboda-data-submission-api/values.yaml`